### PR TITLE
Initial checkin for cinderblock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.egg-info
+.tox/
+build/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # cinderblock
 
 `cinderblock` helps you do Continous Integration with CircleCI across multiple projects.
+
+
+## Install
+- Clone the repo
+- Install via `pip install -e .`
+- The `cinderblock` and `commitstatus` commands should be installed now from your development env
+
+## Test
+- `tox`

--- a/cinderblock/cinderblock.py
+++ b/cinderblock/cinderblock.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+'''
+Triggers an integration CircleCI job
+'''
+
+import argparse
+import os
+from circleclient import circleclient
+
+
+def main():
+    args = __parse_args()
+    client = circleclient.CircleClient(args.circle_api_token)
+
+    # Trigger a parametized build with the integration project with
+    # env variables to identify the trigger project and the version
+    print('Triggering CircleCI build for {}/{}:{} with args: {}'.format(
+        args.repo_owner, args.circle_project_reponame, args.branch, args))
+    client.build.trigger(username=args.repo_owner,
+                         project=args.integration_repo,
+                         branch=args.branch,
+                         CINDERBLOCK_REPO_OWNER=args.repo_owner,
+                         CINDERBLOCK_REPO_NAME=args.circle_project_reponame,
+                         CINDERBLOCK_COMMIT_SHA=args.circle_sha1,
+                         CINDERBLOCK_BUILD_NUM=args.circle_build_num,
+                         CINDERBLOCK_TARGET_URL=args.circle_build_url)
+    print('Build triggered at: https://www.circleci.com/gh/{}/{}/'.format(
+        args.repo_owner, args.integration_repo))
+
+
+def __validate_args(args, argparser):
+    try:
+        assert args.repo_owner, \
+            "repo_owner missing or CINDERBLOCK_REPO_OWNER is not set!"
+        assert args.integration_repo, \
+            "integration_repo missing or CINDERBLOCK_INTEGRATION_REPO is not set!"
+        assert args.circle_api_token, \
+            "CIRCLE_API_TOKEN is not set!"
+        assert args.circle_project_reponame, \
+            "CIRCLE_PROJECT_REPONAME is not set!"
+        assert args.circle_sha1, \
+            "No commit specified or CIRCLE_SHA1 is not set!"
+        assert args.circle_build_num, \
+            "No build number specified or CIRCLE_BUILD_NUMBER is not set!"
+    except AssertionError as error:
+        argparser.print_help()
+        raise error
+
+
+def __parse_args():
+    argparser = argparse.ArgumentParser(description=__doc__)
+    argparser.add_argument(
+        '-o', '--repo-owner', default=os.environ.get('CINDERBLOCK_REPO_OWNER'))
+    argparser.add_argument(
+        '-i', '--integration-repo',
+        default=os.environ.get('CINDERBLOCK_INTEGRATION_REPO'))
+    argparser.add_argument(
+        '-b', '--branch', default='master')
+
+    args = argparser.parse_args()
+    args.circle_api_token = os.environ.get('CIRCLE_API_TOKEN')
+    args.circle_build_num = os.environ.get('CIRCLE_BUILD_NUM')
+    args.circle_sha1 = os.environ.get('CIRCLE_SHA1')
+    args.circle_build_url = os.environ.get('CIRCLE_BUILD_URL')
+    args.circle_project_reponame = os.environ.get('CIRCLE_PROJECT_REPONAME')
+    __validate_args(args, argparser)
+    return args
+
+if __name__ == '__main__':
+    main()

--- a/cinderblock/commitstatus.py
+++ b/cinderblock/commitstatus.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+
+'''
+Posts commit status to GitHub
+
+Works together cinderblock.py which will provide commitstatus.py
+with default values to use
+'''
+
+import requests
+import os
+import json
+import argparse
+import sys
+
+
+def post_github_commit_status(args):
+    data = {"state": args.state,
+            "context": args.context,
+            "description": "{} status: {}".format(args.context, args.state),
+            "target_url": args.target_url}
+    data_json = json.dumps(data)
+    headers = {'Content-Type': 'application/json'}
+    url = "https://api.github.com/repos/{}/{}/statuses/{}?access_token={}".format(
+        args.github_user, args.repo_name, args.commit_sha, args.github_token)
+
+    response = requests.post(url, data=data_json, headers=headers)
+    print("Posting commit status={} for {}/{}/{} got response:\n{}".format(
+        args.state, args.github_user, args.repo_name,
+        args.commit_sha, response.content))
+    return response
+
+
+def __validate_args(args, argparser):
+    try:
+        assert args.target_url, \
+            "target_url missing or CINDERBLOCK_TARGET_URL is not set!"
+        assert args.github_token, \
+            "github_token missing or CINDERBLOCK_GITHUB_TOKEN is not set!"
+        assert args.github_user, \
+            "github_user user missing or CINDERBLOCK_GITHUB_USER is not set!"
+        assert args.commit_sha, \
+            "commit_sha missing or CINDERBLOCK_COMMIT_SHA is not set!"
+        assert args.repo_name, \
+            "repo_name missing or CINDERBLOCK_REPO_NAME is not set!"
+    except AssertionError as error:
+        # Print error/help but don't exit with error since it could be expected
+        argparser.print_help()
+        print(error)
+        sys.exit()
+
+
+def __parse_args():
+    argparser = argparse.ArgumentParser(description=__doc__)
+
+    argparser.add_argument('-s', '--state', default=None, required=True,
+                           help='State: [success | failure | pending ]')
+    argparser.add_argument('-t', '--target-url',
+                           default=os.environ.get('CIRCLE_BUILD_URL'),
+                           help='target_url for the commit status')
+    argparser.add_argument('-u', '--github-user',
+                           default=os.environ.get('CINDERBLOCK_GITHUB_USER'),
+                           help='The GitHub user to send commitstatus to')
+    argparser.add_argument('-c', '--commit-sha',
+                           default=os.environ.get('CINDERBLOCK_COMMIT_SHA'),
+                           help='The git commit SHA to post status to')
+    argparser.add_argument('-r', '--repo-name',
+                           default=os.environ.get('CINDERBLOCK_REPO_NAME'),
+                           help='The GitHub repo')
+    args = argparser.parse_args()
+
+    # Context of the commit status shows info about the integration project
+    # Prepend the github_user to distinguish it more
+    integration_repo = os.environ.get('CIRCLE_PROJECT_REPONAME')
+    args.context = "{}/{}".format(args.github_user, integration_repo)
+
+    args.github_token = os.environ.get('CINDERBLOCK_GITHUB_TOKEN')
+    __validate_args(args, argparser)
+    return args
+
+
+def main():
+    args = __parse_args()
+    post_github_commit_status(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  python:
+    version: 2.7.6
+
+test:
+  override:
+    - tox

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python
+
+import subprocess
+import sys
+
+from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+
+class Tox(TestCommand):
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.tox_args = None
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import tox
+        import shlex
+
+        args = self.tox_args
+        if args:
+            args = shlex.split(self.tox_args)
+        errno = tox.cmdline(args=args)
+        sys.exit(errno)
+
+
+def git_version():
+    try:
+        # Use git to get a version based on the last tag
+        # For stuff in local development, append .9999
+        version = subprocess.check_output(
+            'git describe --tags --dirty --always'.split()
+        ).replace('-dirty', '.9999').strip().decode()
+    except subprocess.CalledProcessError:
+        version = '0.0.0'
+
+    return version
+
+
+if __name__ == '__main__':
+    setup(
+        name='cinderblock',
+        version=git_version(),
+        description='Continous Integration with multiple github projects on CircleCI!',
+        url='https://github.com/paperg/cinderblock',
+        packages=['cinderblock'],
+        entry_points={
+            'console_scripts': [
+                'cinderblock = cinderblock.cinderblock:main',
+                'commitstatus = cinderblock.commitstatus:main',
+            ]
+        },
+        install_requires=[
+            'circleclient',
+            'requests'
+        ]
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27
+
+[testenv]
+commands = flake8
+deps =
+    flake8
+
+[flake8]
+max-line-length = 100
+max-complexity = 10
+exclude=build/*


### PR DESCRIPTION
- `integrate.py` script which triggers a parametized CircleCI job, gets used by the project to integrate
- `commitstatus.py` script which will set the commit status on a given commit, gets used by the integration project

Here's how a project would integrate with cinderblock:
- downstream project (i.e. paperg/template-service): https://github.com/paperg/template-service/issues/532
- integration project (i.e. paperg/integrate): https://github.com/paperg/integration/issues/3

@bitglue 
