### PR TITLE
Pass the API token as env var to the receive repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ they have passed. Now you want integration tests to run.
 
       cinderblock trigger paperg/integration/master
 
-A CircleCI API token which has privileges to trigger a build on the integration
-project must be set in `$CINDERBLOCK_CIRCLE_API_TOKEN`.
+A CircleCI API token which has privileges to trigger a build on the projects
+involved must be set in `$CINDERBLOCK_CIRCLE_API_TOKEN`.  This token gets passed
+as an environment variable between the projects.  This can be used for the 
+receiving project to use CircleCI API to grab artifacts from the triggering 
+projects.
 
 A build of the master branch of the paperg/integration project will be started.
 In that build, cinderblock will set `$CINDERBLOCK_SOURCE_COMMIT` and

--- a/cinderblock/trigger.py
+++ b/cinderblock/trigger.py
@@ -19,6 +19,7 @@ class Trigger(object):
         build_args = {
             'CINDERBLOCK_SOURCE_BUILD': source_build,
             'CINDERBLOCK_SOURCE_COMMIT': source_commit,
+            'CINDERBLOCK_CIRCLE_API_TOKEN': self.circleci_client.api_token
         }
         self.circleci_client.build.trigger(target_owner, target_repo, target_branch, **build_args)
 

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -5,9 +5,9 @@ import pytest
 
 
 class FakeCircleCIClient(object):
-    def __init__(self, api_key):
+    def __init__(self, api_token):
         self._builds_triggered = []
-        self._api_key = api_key
+        self.api_token = api_token
 
         class FakeBuild(object):
             @staticmethod
@@ -17,10 +17,12 @@ class FakeCircleCIClient(object):
 
         self.build = FakeBuild()
 
+fake_api_key = 'api_key'
+
 
 @pytest.fixture
 def trigger():
-    return Trigger('api_key', CircleClient=FakeCircleCIClient)
+    return Trigger(fake_api_key, CircleClient=FakeCircleCIClient)
 
 
 @pytest.fixture
@@ -29,7 +31,7 @@ def circleci_client(api):
 
 
 def test_api_key(trigger):
-    assert trigger.circleci_client._api_key == 'api_key'
+    assert trigger.circleci_client.api_token == fake_api_key
 
 
 def test_interface(trigger):
@@ -57,6 +59,7 @@ def test_trigger_circleci_build(trigger):
     assert build_params == {
         'CINDERBLOCK_SOURCE_BUILD': 'source/build/42',
         'CINDERBLOCK_SOURCE_COMMIT': 'source/commit/12345678deadbeef',
+        'CINDERBLOCK_CIRCLE_API_TOKEN': fake_api_key
     }
 
 


### PR DESCRIPTION
Pass the token from the triggering project to the receiving project
so the token can be used to get artifacts and other circleci things
